### PR TITLE
Leitura via serial

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,5 +35,10 @@
     "raspberry-pi-pico.cmakeAutoConfigure": true,
     "raspberry-pi-pico.useCmakeTools": false,
     "raspberry-pi-pico.cmakePath": "${HOME}/.pico-sdk/cmake/v3.29.9/bin/cmake",
-    "raspberry-pi-pico.ninjaPath": "${HOME}/.pico-sdk/ninja/v1.12.1/ninja"
+    "raspberry-pi-pico.ninjaPath": "${HOME}/.pico-sdk/ninja/v1.12.1/ninja",
+    "files.associations": {
+        "*.html": "html",
+        "*.css": "css",
+        "bootrom.h": "c"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -39,6 +39,8 @@
     "files.associations": {
         "*.html": "html",
         "*.css": "css",
-        "bootrom.h": "c"
+        "bootrom.h": "c",
+        "stdlib.h": "c",
+        "stdio.h": "c"
     }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,8 +41,8 @@ pico_set_program_name(controle-de-pinos-GPIO "controle-de-pinos-GPIO")
 pico_set_program_version(controle-de-pinos-GPIO "0.1")
 
 # Modify the below lines to enable/disable output over UART/USB
-pico_enable_stdio_uart(controle-de-pinos-GPIO 0)
-pico_enable_stdio_usb(controle-de-pinos-GPIO 0)
+pico_enable_stdio_uart(controle-de-pinos-GPIO 1)
+pico_enable_stdio_usb(controle-de-pinos-GPIO 1)
 
 # Add the standard library to the build
 target_link_libraries(controle-de-pinos-GPIO

--- a/controle-de-pinos-GPIO.c
+++ b/controle-de-pinos-GPIO.c
@@ -9,6 +9,7 @@ int main()
 {
     stdio_init_all();
     char command[20];
+    printf("Escreva algum comando: \n");
     while (true)
     {
         if (read_serial_command(command, sizeof(command)))

--- a/controle-de-pinos-GPIO.c
+++ b/controle-de-pinos-GPIO.c
@@ -1,14 +1,44 @@
 #include <stdio.h>
 #include "pico/stdlib.h"
+#include <string.h>
 
-
+// FUNÇÃO PARA LER COMANDOS VIA SERIAL
+int read_serial_command(char *command, size_t size);
 
 int main()
 {
     stdio_init_all();
-
-    while (true) {
-        printf("Hello, world!\n");
-        sleep_ms(1000);
+    char command[20];
+    while (true)
+    {
+        if (read_serial_command(command, sizeof(command)))
+        {
+            printf("comando lido: %s\n", command);
+        }
     }
+}
+
+// FUNÇÃO PARA LER COMANDOS VIA SERIAL-> retorna 1 se tiver alguma leitura e 0 caso contrário
+int read_serial_command(char *command, size_t size)
+{
+    static int index = 0;
+
+    int ch = getchar_timeout_us(10000); // período máximo de 10 milissegundos
+    if (ch != PICO_ERROR_TIMEOUT)
+    {
+        if (ch == '\n' || ch == '\r')
+        {
+            if (index > 0)
+            {
+                command[index] = '\0';
+                index = 0; // após ler o comando volta reseta o índice
+                return 1;  // indica que houve leitura
+            }
+        }
+        else if (index < size - 1)
+        {
+            command[index++] = (char)ch;
+        }
+    }
+    return 0; // indica que não houve leitura
 }

--- a/diagram.json
+++ b/diagram.json
@@ -1,0 +1,19 @@
+{
+  "version": 1,
+  "author": "equipe 2 - subgrupo 4",
+  "editor": "wokwi",
+  "parts": [
+    {
+      "type": "board-pi-pico-w",
+      "id": "pico",
+      "top": -51.25,
+      "left": 32.35,
+      "attrs": { "builder": "pico-sdk" }
+    }
+  ],
+  "connections": [
+    ["pico:GP0", "$serialMonitor:RX", "", []],
+    ["pico:GP1", "$serialMonitor:TX", "", []]
+  ],
+  "dependencies": {}
+}

--- a/wokwi.toml
+++ b/wokwi.toml
@@ -1,0 +1,4 @@
+[wokwi]
+version = 1
+firmware = 'build\controle-de-pinos-GPIO.uf2'
+elf = 'build\controle-de-pinos-GPIO.elf'


### PR DESCRIPTION
---
# Adiciona função modular para leitura de comandos via serial e configuração para Wokwi
---
## Descrição
Este PR adiciona melhorias ao projeto, incluindo:

```Função read_serial_command ```:

- Modulariza a leitura de comandos recebidos via serial.
- Implementa suporte a timeout configurável (10ms) para leitura não bloqueante.
- Retorna 1 se um comando completo (terminado por \n ou \r) for lido.
- Retorna 0 caso nenhuma entrada seja detectada no período de timeout.
- Simplifica o código principal ao delegar a responsabilidade da leitura à nova função.

```Configuração para Wokwi```:

Inclui suporte para rodar o projeto na extensão **Wokwi**, permitindo emulação e testes facilitados no ambiente simulado.