### PR TITLE
Adiciona função de  Processamento de Comandos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ pico_enable_stdio_usb(controle-de-pinos-GPIO 1)
 
 # Add the standard library to the build
 target_link_libraries(controle-de-pinos-GPIO
-        pico_stdlib)
+        pico_stdlib pico_bootrom)
 
 # Add the standard include files to the build
 target_include_directories(controle-de-pinos-GPIO PRIVATE

--- a/controle-de-pinos-GPIO.c
+++ b/controle-de-pinos-GPIO.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include "pico/stdlib.h"
 #include <string.h>
+#include "pico/bootrom.h"
 
 // FUNÇÃO PARA LER COMANDOS VIA SERIAL
 int read_serial_command(char *command, size_t size);
@@ -52,6 +53,13 @@ void process_command(const char *command)
     if (strcmp(command, "ON") == 0)
     {
         //    E CONTINUA DAQUI
+    }
+    else if (strcmp(command, "BOOT") == 0)
+    {
+        // SÓ FUNCIONA NO HARDWARE - NA SIMULAÇÃO N FAZ NADA :-P
+        printf("Reiniciando no modo bootloader...\n");
+        sleep_ms(500);
+        reset_usb_boot(0, 0);
     }
     else
     {

--- a/controle-de-pinos-GPIO.c
+++ b/controle-de-pinos-GPIO.c
@@ -4,6 +4,8 @@
 
 // FUNÇÃO PARA LER COMANDOS VIA SERIAL
 int read_serial_command(char *command, size_t size);
+// FUNÇÃO PARA PROCESSAR OS COMANDOS LIDOS
+void process_command(const char *command);
 
 int main()
 {
@@ -15,6 +17,7 @@ int main()
         if (read_serial_command(command, sizeof(command)))
         {
             printf("comando lido: %s\n", command);
+            process_command(command);
         }
     }
 }
@@ -42,4 +45,16 @@ int read_serial_command(char *command, size_t size)
         }
     }
     return 0; // indica que não houve leitura
+}
+
+void process_command(const char *command)
+{
+    if (strcmp(command, "ON") == 0)
+    {
+        //    E CONTINUA DAQUI
+    }
+    else
+    {
+        printf("Comando não reconhecido: %s\n", command);
+    }
 }


### PR DESCRIPTION
---
# Adiciona função para processamento de comandos via serial, incluindo suporte ao modo bootloader
---
## Descrição
Este PR melhora a estrutura e funcionalidade do código, com as seguintes alterações principais:

- Adiciona a função ```process_command```, responsável por interpretar comandos recebidos e executar ações específicas.
- Implementa o comando **BOOT**, que reinicia a placa no modo bootloader, permitindo atualizações ou reconfiguração direta via software.
- Inclui mensagens informativas para comandos reconhecidos e tratamento para comandos inválidos.
- Função de leitura serial melhorada ```read_serial_command```
- Inclui uma mensagem de prompt ao usuário para iniciar a interação ("Escreva algum comando: ").